### PR TITLE
Remove intermediate unpacked rootfs directory

### DIFF
--- a/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
@@ -47,3 +47,4 @@ fi
 touch $ROOTFS_DIR
 
 tar -C $ROOTFS_DIR -cf $ROOTFS_TAR .
+rm -rf $ROOTFS_DIR


### PR DESCRIPTION
The intermediate directory where the rootfs tgz file is unpacked is no longer used and takes up ~1G extra space

If this is merged, it can also be applied to cflinuxfs2-release