### PR TITLE
Make `pre-start` safe to run multiple times

### DIFF
--- a/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
@@ -15,7 +15,7 @@ fi
 
 if grep -q "trusted_ca_certificates" $TRUSTED_CERT_FILE; then
   JSON_CERT_FILE=$CONF_DIR/certs/trusted_ca.json
-  mv $TRUSTED_CERT_FILE $JSON_CERT_FILE
+  cp $TRUSTED_CERT_FILE $JSON_CERT_FILE
   TRUSTED_CERT_FILE=$JSON_CERT_FILE
 fi
 


### PR DESCRIPTION
As described in cloudfoundry/cflinuxfs3-release#5 :

> the pre-start script of the cflinuxfs3-rootfs-setup job is not
> idempotent. It can happen under certain circumstances that BOSH runs the
> script twice which leads to the following error:

```
2019/04/10 12:20:25 open
/var/vcap/jobs/cflinuxfs3-rootfs-setup/config/certs/trusted_ca.crt: no such file or directory
```

As @philippthun suggests in that ticket, this can be solved by replacing
the `mv` with `cp`, which will leave the original cert in place for the
next time the script runs.

Supersedes #6 