### PR TITLE
Change certsplitter package name to avoid cflinuxfs2 conflict

### DIFF
--- a/jobs/cflinuxfs3-rootfs-setup/spec
+++ b/jobs/cflinuxfs3-rootfs-setup/spec
@@ -7,7 +7,7 @@ templates:
 
 packages:
   - cflinuxfs3
-  - rootfs-certsplitter
+  - rootfs-certsplitter-cflinuxfs3
 
 properties:
   cflinuxfs3-rootfs.trusted_certs:

--- a/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
@@ -21,7 +21,7 @@ fi
 
 rm -f $ROOTFS_DIR/usr/local/share/ca-certificates/*
 mkdir -p $CA_DIR
-/var/vcap/packages/rootfs-certsplitter/bin/certsplitter $TRUSTED_CERT_FILE $CA_DIR
+/var/vcap/packages/rootfs-certsplitter-cflinuxfs3/bin/certsplitter $TRUSTED_CERT_FILE $CA_DIR
 chmod 0644 $CA_DIR/*
 
 # have to set TMPDIR so we can mktemp inside the chrooted subshell

--- a/packages/rootfs-certsplitter/spec
+++ b/packages/rootfs-certsplitter/spec
@@ -1,5 +1,5 @@
 ---
-name: rootfs-certsplitter
+name: rootfs-certsplitter-cflinuxfs3
 
 dependencies:
   - golang-1.11-linux


### PR DESCRIPTION
Hello buildpacks team,

We're getting some name collisions with other packages.

Signed-off-by: Carlos Iriarte <ciriarte@pivotal.io>