### PR TITLE
Mention that trusted_certs property accepts array of certs

### DIFF
--- a/jobs/cflinuxfs3-rootfs-setup/spec
+++ b/jobs/cflinuxfs3-rootfs-setup/spec
@@ -11,7 +11,7 @@ packages:
 
 properties:
   cflinuxfs3-rootfs.trusted_certs:
-    description: "Concatenation of PEM-encoded CA certficates to add to the rootfs trust store."
+    description: "Array or concatenation of PEM-encoded CA certficates to add to the rootfs trust store."
     example: |
       -----BEGIN CERTIFICATE-----
       (contents of certificate #1)


### PR DESCRIPTION
Hi Team,

Array of certs format is used in cf-deployment manifest. I was a bit confused when noticed this change during the migration from `cflinuxfs2`.
https://github.com/cloudfoundry/cf-deployment/blob/73fba591a4abdb82e70da9b14dd314600744d8e8/cf-deployment.yml#L1564-L1569

It make sense to mention this in `cflinuxfs3-rootfs-setup` jobs spec. 