### PR TITLE
feat: Make rootfs destination configurable

### DIFF
--- a/jobs/cflinuxfs3-rootfs-setup/spec
+++ b/jobs/cflinuxfs3-rootfs-setup/spec
@@ -19,3 +19,7 @@ properties:
       -----BEGIN CERTIFICATE-----
       (contents of certificate #2)
       -----END CERTIFICATE-----
+
+  cflinuxfs3-rootfs.destination:
+    description: "Destination path for the rootfs, tarball and unpacked."
+    default: "/var/vcap/packages/cflinuxfs3"

--- a/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs3-rootfs-setup/templates/pre-start
@@ -2,9 +2,10 @@
 # vim: set ft=sh
 
 CONF_DIR=/var/vcap/jobs/cflinuxfs3-rootfs-setup/config
+ROOTFS_DESTINATION=<%= p("cflinuxfs3-rootfs.destination") %>
 ROOTFS_PACKAGE=/var/vcap/packages/cflinuxfs3
-ROOTFS_DIR=$ROOTFS_PACKAGE/rootfs
-ROOTFS_TAR=$ROOTFS_PACKAGE/rootfs.tar
+ROOTFS_DIR=$ROOTFS_DESTINATION/rootfs
+ROOTFS_TAR=$ROOTFS_DESTINATION/rootfs.tar
 TRUSTED_CERT_FILE=$CONF_DIR/certs/trusted_ca.crt
 CA_DIR=$ROOTFS_DIR/usr/local/share/ca-certificates/
 


### PR DESCRIPTION
New property `cflinuxfs3-rootfs.destination` to set the destination.
Defaults to standard destination location, same as the origin location.

The change allows SUSE to redirect the destination in their containerization without having to patch system sources. After the change this can be done properly via ops files changing the relevant properties.

Origin ticket: cloudfoundry-incubator/kubecf#505 (Links to (semi-)related PRs).